### PR TITLE
Add Supplemental information for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,9 @@ call ddu#custom#patch_global({
     \   },
     \ })
 ```
+
+### For macOS
+Because of the use of the gio command, `desktop-file-utils` must be installed on macOS.
+```bash
+$ brew install desktop-file-utils
+```


### PR DESCRIPTION
Because of the use of the gio command, `desktop-file-utils` must be installed on macOS.