### PR TITLE
prevent save_cursor with quitted

### DIFF
--- a/autoload/ddu/ui/filer.vim
+++ b/autoload/ddu/ui/filer.vim
@@ -117,10 +117,15 @@ function! ddu#ui#filer#_highlight(
 endfunction
 
 function! ddu#ui#filer#_save_cursor(path) abort
+  if a:path ==# ''
+    return
+  endif
+
   let b:ddu_ui_filer_cursor_pos = getcurpos()
   let b:ddu_ui_filer_cursor_text = getline('.')
 
-  if a:path ==# ''
+  " Prevent from saving in quitted
+  if b:ddu_ui_filer_cursor_text ==# ''
     return
   endif
 


### PR DESCRIPTION
uiを閉じた直後にカーソルを動かすとCursorMovedイベントによるカーソル位置保存が暴発することがあるようでした。

暴発時は `b:ddu_ui_filer_cursor_text` が空文字になることを利用して回避してみました。