### PR TITLE
Use Vim's cwd if `source.path` is empty

### DIFF
--- a/denops/@ddu-uis/filer.ts
+++ b/denops/@ddu-uis/filer.ts
@@ -779,18 +779,22 @@ export class Ui extends BaseUi<Params> {
       // Create root item from source directory
 
       // Replace the home directory.
+      let root = source.path;
+      if (root == "") {
+        root = await fn.getcwd(denops) as string;
+      }
+      let display = root;
       const home = env.get("HOME", "");
-      let display = source.path;
       if (home && home != "") {
         display = display.replace(home, "~");
       }
 
       ret.push({
-        word: source.path,
+        word: root,
         display: `${source.name}:${display}`,
         action: {
           isDirectory: true,
-          path: source.path,
+          path: root,
         },
         highlights: [
           {
@@ -808,7 +812,7 @@ export class Ui extends BaseUi<Params> {
         ],
         kind: source.kind,
         isTree: true,
-        treePath: source.path,
+        treePath: root,
         matcherKey: "word",
         __sourceIndex: source.index,
         __sourceName: source.name,


### PR DESCRIPTION
## Problem
If `sourceOptions.path == ""`, root file name is not displayed.

![image](https://user-images.githubusercontent.com/63794197/223159714-2639eb64-0f4c-4cca-9861-594212ab26cc.png)

## Solution
Use Vim function `getcwd()` to get cwd.
