### PR TITLE
Add `floatingBorder` parameter

### DIFF
--- a/denops/@ddu-uis/filer.ts
+++ b/denops/@ddu-uis/filer.ts
@@ -63,6 +63,7 @@ export type Params = {
   sortTreesFirst: boolean;
   split: "horizontal" | "vertical" | "floating" | "no";
   splitDirection: "botright" | "topleft";
+  floatingBorder: FloatingBorder;
   statusline: boolean;
   winCol: number;
   winHeight: number;
@@ -218,6 +219,7 @@ export class Ui extends BaseUi<Params> {
           "col": Number(args.uiParams.winCol),
           "width": Number(args.uiParams.winWidth),
           "height": winHeight,
+          "border": args.uiParams.floatingBorder,
         });
 
         const highlight = args.uiParams.highlights?.floating ?? "NormalFloat";

--- a/doc/ddu-ui-filer.txt
+++ b/doc/ddu-ui-filer.txt
@@ -161,6 +161,15 @@ focus		(boolean)
 
 		Default: v:true
 
+  				    	*ddu-ui-filer-param-floatingBorder*
+floatingBorder	(string | list)
+		Specify the style of the window border if
+		|ddu-ui-filer-param-split| is "floating".
+		See |nvim_open_win()| for the detail.
+		NOTE: It is neovim only.
+
+		Default: "none"
+
 				    	*ddu-ui-filer-param-highlights*
 highlights	(dictionary)
 		It specifies ddu-ui-filer buffer highlights.


### PR DESCRIPTION
Thank you for adding `highlights.flotaingBorder` parameter alongside with ddu-ui-ff.
However, ddu-ui-filer didn't support `floatingBorder` parameter in the first place.
This PR adds the missing parameter.