### PR TITLE
feat: add previewExecute action

### DIFF
--- a/denops/@ddu-ui-filer/preview.ts
+++ b/denops/@ddu-ui-filer/preview.ts
@@ -56,6 +56,16 @@ export class PreviewUi {
     });
   }
 
+  async execute(
+    denops: Denops,
+    command: string,
+  ) {
+    if (this.previewWinId < 0) {
+      return;
+    }
+    await fn.win_execute(denops, this.previewWinId, command);
+  }
+
   async previewContents(
     denops: Denops,
     context: Context,

--- a/denops/@ddu-uis/filer.ts
+++ b/denops/@ddu-uis/filer.ts
@@ -60,6 +60,10 @@ type OnPreviewArguments = {
   previewWinId: number;
 };
 
+type PreviewExecuteParams = {
+  command: string;
+};
+
 export type Params = {
   floatingBorder: FloatingBorder;
   floatingTitle: FloatingTitle;
@@ -774,6 +778,14 @@ export class Ui extends BaseUi<Params> {
         await this.getBufnr(args.denops),
         item,
       );
+    },
+    previewExecute: async (args: {
+      denops: Denops;
+      actionParams: unknown;
+    }) => {
+      const command = (args.actionParams as PreviewExecuteParams).command;
+      await this.previewUi.execute(args.denops, command);
+      return ActionFlags.Persist;
     },
     quit: async (args: {
       denops: Denops;


### PR DESCRIPTION
I want to add "previewExecute" action, it provides preview window operation to user.

I mainly intend to scrolling preview window.

# example

```vim
nnoremap <buffer> <nowait> d <Cmd>call ddu#ui#do_action('previewExecute', #{command: "normal! \<C-d>"})<CR>
nnoremap <buffer> <nowait> u <Cmd>call ddu#ui#do_action('previewExecute', #{command: "normal! \<C-u>"})<CR>
```

See also: https://github.com/Shougo/ddu-ui-ff/pull/100