### PR TITLE
fix: use ddu#ui#filer#_max_row instead of ddu#ui#ff#_max_row

### DIFF
--- a/autoload/ddu/ui/filer.vim
+++ b/autoload/ddu/ui/filer.vim
@@ -46,7 +46,7 @@ function ddu#ui#filer#_highlight_items(
     call prop_clear(1, a:max_lines + 1, { 'bufnr': a:bufnr })
   endif
 
-  const max_row = ddu#ui#ff#_max_row(a:bufnr)
+  const max_row = ddu#ui#filer#_max_row(a:bufnr)
 
   " Highlights items
   for item in a:highlight_items


### PR DESCRIPTION
Using `ddu#ui#ff#_max_row` created a dependency on `ddu-ui-ff`.

I have changed it to use `ddu#ui#filer#_max_row` instead.